### PR TITLE
Fix absolute paths

### DIFF
--- a/airflow.py
+++ b/airflow.py
@@ -30,8 +30,12 @@ dag = DAG(
     schedule_interval=timedelta(days=1),
 )
 
-db_name = 'ecommerce.db'
-path = "/Users/junior/Documents/github/ecommerce/transactions_fixed.json"
+import os
+
+# Paths relative to this file for portability
+BASE_DIR = os.path.dirname(__file__)
+db_name = os.path.join(BASE_DIR, 'ecommerce.db')
+path = os.path.join(BASE_DIR, 'transactions_fixed.json')
 name_cust = "Customers"
 name_prd = "Products"
 name_sls = 'sales'

--- a/fixed_json_file.py
+++ b/fixed_json_file.py
@@ -1,7 +1,10 @@
 import json
+import os
 
-file_path = "/Users/junior/Documents/github/ecommerce/transactions.json"
-new_path = "/Users/junior/Documents/github/ecommerce/transactions_fixed.json"
+# Work with paths relative to this script
+BASE_DIR = os.path.dirname(__file__)
+file_path = os.path.join(BASE_DIR, "transactions.json")
+new_path = os.path.join(BASE_DIR, "transactions_fixed.json")
 
 with open(file_path, "r", encoding="utf-8") as f:
     data = json.load(f)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,11 @@
 from data_ingestion import *
 import numpy as np
+import os
 
-path = "/Users/junior/Documents/github/ecommerce/transactions_fixed.json"
-db_name = 'ecommerce.db'
+# Use a path relative to this file to improve portability
+BASE_DIR = os.path.dirname(__file__)
+path = os.path.join(BASE_DIR, "transactions_fixed.json")
+db_name = os.path.join(BASE_DIR, 'ecommerce.db')
 
 if __name__ == "__main__":
     conn = conn_sqlite(db_name)

--- a/test.py
+++ b/test.py
@@ -2,9 +2,11 @@ import sqlite3
 import pandas as pd
 import matplotlib.pyplot as plt
 import ace_tools_open as tools
+import os
 
-# Connexion à la base SQLite
-db_name = "ecommerce.db"
+# Connexion à la base SQLite avec un chemin relatif
+BASE_DIR = os.path.dirname(__file__)
+db_name = os.path.join(BASE_DIR, "ecommerce.db")
 conn = sqlite3.connect(db_name)
 
 # Récupération des données


### PR DESCRIPTION
## Summary
- use relative paths in main script
- make airflow use relative paths
- allow fixed_json_file to work without hardcoded directories
- adjust test utility to use relative paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b316e11208325a3de2ad5306fe731